### PR TITLE
Звания и много мелочей

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import os
+import unittest
+from ww6StatBot import Bot
+from unittest.mock import patch, PropertyMock, Mock
+from telegram import User
+
+class TestBot(unittest.TestCase):
+    db_path = 'test.sqlite'
+
+    def setUp(self):
+        # Patch things
+        patcher = patch.object(Bot, 'db_path', new_callable=PropertyMock, return_value=self.db_path)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        # Create bot instance
+        self.bot = Bot()
+        # Patch send_message method
+        self.addCleanup(self.bot.stop)
+    
+    def test_demand_squads(self):
+        bot = self.bot
+        
+        # add squads
+        chat_id = 123456789
+        bot.squadnames['sq'] = 'Squad name'
+        bot.squadids['sq'] = chat_id
+        bot.squads_by_id[chat_id] = 'sq'
+
+        chat_id = 987654321
+        bot.squadnames['la'] = 'Los Angeles'
+        bot.squadids['la'] = chat_id
+        bot.squads_by_id[chat_id] = 'la'
+
+        class Player(object):
+            id = None
+            chatid = None
+            username = None
+
+        user_id = 123123
+        chat_id = 321321
+        user = User(user_id, False, 'Drobb', '', 'drobb')
+        bot.users[user_id] = Player()
+        bot.users[user_id].id = user_id
+        bot.users[user_id].chatid = chat_id
+        bot.users[user_id].username = 'drobb'
+        bot.usersbyname['drobb'] = user_id
+        bot.admins.add(user_id)
+
+        send_mock = Mock()
+        bot.message_manager.send_message = send_mock
+
+        text = '/echo Привет!'
+        sqs, msg = bot.demand_squads(text, user, allow_empty_squads=True)
+        self.assertEqual(sqs, [])
+        self.assertEqual(msg, 'Привет!')
+
+        text = '/echo sq'
+        sqs, msg = bot.demand_squads(text, user, allow_empty_squads=True)
+        self.assertEqual(sqs, None)
+        self.assertEqual(msg, None)
+        send_mock.assert_called()
+
+        text = '/echo sq Привет!'
+        sqs, msg = bot.demand_squads(text, user, allow_empty_squads=True)
+        self.assertEqual(sqs, ['sq',])
+        self.assertEqual(msg, 'Привет!')
+
+        text = '/echo sq la Привет!'
+        sqs, msg = bot.demand_squads(text, user, allow_empty_squads=True)
+        self.assertEqual(sqs, ['sq', 'la'])
+        self.assertEqual(msg, 'Привет!')
+
+        text = '/echo sq la Привет!'
+        sqs, msg = bot.demand_squads(text, user, allow_empty_squads=True, default_message="Пинпинпин")
+        self.assertEqual(sqs, ['sq', 'la'])
+        self.assertEqual(msg, 'Привет!')
+
+        text = '/echo sq la'
+        sqs, msg = bot.demand_squads(text, user, allow_empty_squads=True, default_message="Пинпинпин")
+        self.assertEqual(sqs, ['sq', 'la'])
+        self.assertEqual(msg, "Пинпинпин")
+
+        text = '/echo sq la /autoping ls la'
+        sqs, msg = bot.demand_squads(text, user, allow_empty_squads=True, default_message="Пинпинпин")
+        self.assertEqual(sqs, ['sq', 'la'])
+        self.assertEqual(msg, '/autoping ls la')
+
+    def tearDown(self):
+        if os.path.isfile(self.db_path):
+            os.remove(self.db_path)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ww6StatBot.py
+++ b/ww6StatBot.py
@@ -156,12 +156,10 @@ class Bot:
         self.updater.dispatcher.add_handler(massage_handler)
         self.updater.dispatcher.add_handler(join_handler)
         self.updater.dispatcher.add_handler(callback_handler)
-        self.updater.start_polling(clean=True)
 
         print("admins:", self.admins)
         print("squadnames:", self.squadnames.keys())
         print("users", self.usersbyname.keys())
-        self.updater.idle()
 
     def configure(self):
         f = open(self.CONFIG_PATH)
@@ -199,6 +197,7 @@ class Bot:
                     'password': proxy_config['password']
                 }
             }
+        f.close()
 
     def handle_start(self, bot, update):
         message = update.message
@@ -1353,7 +1352,15 @@ class Bot:
                                                   text="Неизвестная команда... Сам придумал?")
 
     def start(self):
-        self.updater.start_polling()
+        self.updater.start_polling(clean=True)
+        self.updater.idle()
+    
+    def stop(self):
+        self.updater.stop()
+        self.message_manager.stop()
+        if self.notificator:
+            self.notificator.stop()
+        self.timer.stop()
 
     def handle_massage(self, bot, update: telega.Update):
         if update.channel_post:

--- a/ww6StatBot.py
+++ b/ww6StatBot.py
@@ -756,7 +756,7 @@ class Bot:
             res += 'Игроки из других отрядов:\n\t' + '\n\t'.join(difsq) + '\n\t'
         if average:
             res += 'Игроки из этого отряда:\n\t' + '\n\t'.join(average) + '\n\t'
-            self.message_manager.send_message(chat_id=chat_id, text=res, parse_mode='HTML')
+        self.message_manager.send_split(res, chat_id, 50)
 
     def handle_post(self, message: telega.Message):
         chat_from = message.chat
@@ -1311,7 +1311,7 @@ class Bot:
             self.list_squads(chat_id, (user.id in self.admins))
         elif command == 'whois':
             self.who_is(chat_id, text)
-        elif command == 'whospy':
+        elif command == 'whospy' or command == 'who_spy':
             self.who_spy(chat_id, user, message)
         elif command == 'raidson':
             m = re.match(r'^[\S]+[\s]+((?P<g>[\S]+)[\s]+)?(?P<n>[\d]+)', text)

--- a/ww6StatBot.py
+++ b/ww6StatBot.py
@@ -1434,11 +1434,11 @@ class Bot:
                 self.message_manager.send_message(chat_id=chat_id,
                                                   text="А ты смелый! Просить меня о таком...")
                 return
-            text = "<b>Админы</b>\n\t{}\n<b>Командиры</b>\n\t{}".format(
+            text = "<b>Админы</b>\n\t{}\n\n<b>Командиры</b>\n\t{}".format(
                 "\n\t".join(["@" + self.users[uid].username for uid in self.admins]),
-                "\n\t".join(["@{} <b>{}</b>".format(self.users[uid].username, " ".join(self.masters[uid]))
+                "\n\t".join(["{} <b>{}</b>".format('@{}'.format(self.users[uid].username) if uid in self.users else '#{}'.format(uid), " ".join(self.masters[uid]))
                              for uid in self.masters.keys()]))
-            self.message_manager.send_message(chat_id=chat_id, text=text, parse_mode="HTML")
+            self.message_manager.send_split(text, chat_id, 50)
         elif command == 'when_raid':
             now = datetime.datetime.now()
             raid_h = ((int(now.hour) + 7) // 8) * 8 + 1

--- a/ww6StatBot.py
+++ b/ww6StatBot.py
@@ -607,6 +607,9 @@ class Bot:
                 start = text.find(word)
                 break
 
+        if start < 0:
+            start = 0
+
         # Is there any squads?
         if not sqs:
             if not allow_empty_squads:
@@ -630,9 +633,11 @@ class Bot:
             self.message_manager.send_message(chat_id=self.users[user.id].chatid, text=message_text)
             return None, None
 
-        if not text[start:] and not default_message:
+        if (not text[start:] or (start == 0)) and not default_message:
             self.message_manager.send_message(chat_id=self.users[user.id].chatid, text="Но что же мне им написать?")
             return None, None
+        if start == 0:
+            return sqs, default_message
         return sqs, text[start:] or default_message
 
     def user_has_squad_permission(self, user: telega.User, squad: str) -> bool:

--- a/ww6StatBotEvents.py
+++ b/ww6StatBotEvents.py
@@ -5,12 +5,13 @@ import telegram as telega
 from ww6StatBotPlayer import PlayerSettings, Player
 
 class Notificator:
-    def __init__(self, players :dict, bot:telega.Bot):
+    def __init__(self, players: dict, bot: telega.Bot):
         """we assume that settings.notif_time is equal for all players and players is not empty"""
         self.players = players
         self.bot = bot
         dt, t = self._next_time()
-        threading.Timer(dt, self.notify, args=[t]).start()
+        self.timer = threading.Timer(dt, self.notify, args=[t])
+        self.timer.start()
 
     def _next_time(self):
         now = datetime.datetime.now()
@@ -47,4 +48,8 @@ class Notificator:
                     pass
 
         dt, t = self._next_time()
-        threading.Timer(dt, self.notify, args=[t]).start()
+        self.timer = threading.Timer(dt, self.notify, args=[t])
+        self.timer.start()
+
+    def stop(self):
+        self.timer.cancel()

--- a/ww6StatBotUtils.py
+++ b/ww6StatBotUtils.py
@@ -19,7 +19,7 @@ class MessageManager:
 
     def __del__(self):
         try:
-            self._msg_queue.stop()
+            self.stop()
         except:
             pass
 
@@ -70,6 +70,13 @@ class MessageManager:
             self._updates.clear()
         for up in ups:
             self._update_msg(*up[0], **up[1])
+    
+    def stop(self):
+        self._msg_queue.stop()
+        if hasattr(self._timer, 'stop'):
+            self._timer.stop()
+        if hasattr(self._timer, 'cancel'):
+            self._timer.cancel()
 
     @mq.queuedmessage
     def _update_msg(self, *args, **kwargs):
@@ -108,7 +115,7 @@ class Timer:
 
     def stop(self):
         with self._lock:
-            goone = False
+            self._goone = False
             self._thread.join()
 
     def delete(self, ind):


### PR DESCRIPTION
Мелочи:
- Из-за запуска бота сразу при инициализации было сложно воткнуть тесты. Запуск перенесён отдельно в start() (a7d5c3a).
- При остановке бота по ctrl+c бот не останавливается, потому что висят какие-то не закрытые корректно треды. Для тестов воткнул .stop(), закрываю в нём всё что можно, при его вызове всё завершается корректно. По ctrl+c осталось по прежнему, надо разбираться (или не надо) (всё тот же a7d5c3a).
- Для demand_squads написан тест (95 строчек) и фикс его странному поведению (4 строчки) (2d70dfc).
- who_is_at_command заработала. Дело было не в большом количестве символов (как предполагалось), а в удалённом из бота юзере, который остался в списке мастеров. Теперь такое выводится корректно, но разбивка по длине тоже есть (ed0fdf0). Uid #186497448, ld, можешь сразу грохнуть в базе на проде, если есть желание.
- who_spy работает как who_spy (вечно забываю нужно ли там подчёркивание), разбивается по длине, выводит сообщение даже если в списке нет ни одного игрока из этого отряда (a8b67df).

То, ради чего всё (5600bd8):
Звания. Добавляются, удаляются по одному и целиком, в табличке хранятся.
Нафига я воткнул туда json, если можно было просто разделить через «;»? Чтобы не возиться с экранированием. Мне было очень лень возиться с экранированием, правда. А надеяться что никто не придумает влепить «;» в звание я бы точно не стал.